### PR TITLE
Pagination repo

### DIFF
--- a/READme.md
+++ b/READme.md
@@ -170,3 +170,7 @@ Dans le fichier **index.html.twig** ajouter une div qui contient la pagination :
     {{ knp_pagination_render(posts) }}
 </div>
 ```
+
+### ✅Retourner directement des articles paginés
+Au lieu de retourner des articles, puis de les paginer il est beaucoup plus logique de
+les paginer dans la requête du **repository**.

--- a/READme.md
+++ b/READme.md
@@ -173,4 +173,8 @@ Dans le fichier **index.html.twig** ajouter une div qui contient la pagination :
 
 ### ✅Retourner directement des articles paginés
 Au lieu de retourner des articles, puis de les paginer il est beaucoup plus logique de
-les paginer dans la requête du **repository**.
+les paginer dans la requête du **repository**. Au lieu d'avoir la logique de la pagination dans le repo
+on met tout dans le repository :
+```
+return $post = $this->paginator->paginate($data, $page, 9);
+```

--- a/src/Controller/Blog/PostController.php
+++ b/src/Controller/Blog/PostController.php
@@ -3,9 +3,6 @@
 namespace App\Controller\Blog;
 
 use App\Repository\Post\PostRepository;
-use Knp\Component\Pager\Pagination\PaginationInterface;
-use Knp\Component\Pager\Paginator;
-use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,19 +13,11 @@ class PostController extends AbstractController
     #[Route('/', name: 'post.index', methods: ['GET'])]
     public function index(
         PostRepository $postRepository,
-        PaginatorInterface $pagination,
         Request $request
     ): Response
     {
-        $data = $postRepository->findPublished();
-        $post = $pagination->paginate(
-            $data,
-            $request->query->getInt('page', 1),
-            9
-        );
-
         return $this->render('pages/blog/index.html.twig', [
-            'posts' => $post
+            'posts' => $post = $postRepository->findPublished($request->query->getInt('page', 1)),
         ]);
     }    
 }

--- a/src/Repository/Post/PostRepository.php
+++ b/src/Repository/Post/PostRepository.php
@@ -5,6 +5,8 @@ namespace App\Repository\Post;
 use App\Entity\Post\Post;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Knp\Component\Pager\Pagination\PaginationInterface;
+use Knp\Component\Pager\PaginatorInterface;
 
 /**
  * @extends ServiceEntityRepository<Post>
@@ -16,7 +18,10 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class PostRepository extends ServiceEntityRepository
 {
-    public function __construct(ManagerRegistry $registry)
+    public function __construct(
+        ManagerRegistry $registry,
+        private readonly PaginatorInterface $paginator
+    )
     {
         parent::__construct($registry, Post::class);
     }
@@ -24,16 +29,20 @@ class PostRepository extends ServiceEntityRepository
     /**
      * Get published posts
      *
-     * @return array
+     * @param int $page
+     * @return PaginationInterface
      */
-    public function findPublished(): array
+    public function findPublished(int $page): PaginationInterface
     {
-        return $this->createQueryBuilder('p')
+        $data = $this->createQueryBuilder('p')
             ->where('p.state LIKE :state')
             ->setParameter('state', '%STATE_PUBLISHED%')
             ->orderBy('p.createdAt', 'DESC')
             ->getQuery()
             ->getResult()
         ;
+
+        return $post = $this->paginator->paginate($data, $page, 9);
+
     }
 }


### PR DESCRIPTION
### ✅Retourner directement des articles paginés
Au lieu de retourner des articles, puis de les paginer il est beaucoup plus logique de
les paginer dans la requête du **repository**. Au lieu d'avoir la logique de la pagination dans le repo
on met tout dans le repository :
```
return $post = $this->paginator->paginate($data, $page, 9);
```