### PR TITLE
création de la page détail d'un article

### DIFF
--- a/READme.md
+++ b/READme.md
@@ -1,12 +1,15 @@
-# Projet de Blog 
+# Projet de Blog
 
 ### 📋 Création du projet
+
 ```symfony new nomduprojet --webapp```
 
 ### 🔥 Mise en place de Webpack
+
 ```composer require symfony/webpack-encore-bundle```
 
-### 🔽 Installation de Yarn et lancement du server web Symfony 
+### 🔽 Installation de Yarn et lancement du server web Symfony
+
 ```
 composer require symfony/webpack-encore-bundle
 yarn install
@@ -15,11 +18,13 @@ yarn run dev --watch
 ```
 
 ### 📝 Mise en place de l'environnement de test
+
 Créer l'environnement de test pour **Unit** mais aussi pour **Functional**
 Pour lancer les tests : <br>
 ```php bin/phpunit```
 
 ### ✅ Création de l'entité Post
+
 Créer l'entité Post grâce au maker bundle mais en ajoutant le contenu à la main <br>
 ```console make:entity NameEntity``` <br>
 Faire les migrations <br>
@@ -27,26 +32,32 @@ Faire les migrations <br>
 ```console doctrine:migrations:migrate```
 
 ### 🔥 Mise en place d'un Slug avec Cocur/Slugify
+
 Installer la librairie grâce à composer <br>
 ```composer require cocur/slugify``` <br>
 et mettre un évènement prePersist en place pour générer automatiquement le slug
 
 ### ✅ Rendre l'Entité unique avec Unique Entity
+
 Ajouter le tag Unique Entity sur l'entité concernée
 ```#[UniqueEntity('nomdelapropriété')]```
 On peut ajouter un message personnalisé.
 
 ### 🔥 Mise en place de VichUploader
+
 Installer Vichuploader à l'aide de composer <br>
 ```composer require vich/uploader-bundle``` <br>
-Mettre en place le bundle dans une entité **Thumbnail** en relation avec une entité existante pour plus de cohérence (ex: Product => Thumbnail).
+Mettre en place le bundle dans une entité **Thumbnail** en relation avec une entité existante pour plus de cohérence (
+ex: Product => Thumbnail).
 Mettre à jour l'entité miroir. Supprimer les migrations pour avoir une seule et unique migration pour l'entité **Post**.
 
 ### ✅ Mettre en place les fixtures
+
 Installer les fixtures et faker <br>
 ```composer req orm-fixtures``` <br>
 ```composer req fakerphp/faker``` <br>
-Renommer le fichier dans DataFixtures, et créer les fixtures dans EntitéFixtures. Se référer à la doc pour plus d'informations.
+Renommer le fichier dans DataFixtures, et créer les fixtures dans EntitéFixtures. Se référer à la doc pour plus
+d'informations.
 Attention à bien annoter les champs obligatoires qui ne sont pas présents dans les fixtures avec
 > #[ORM\PrePersist] <br>
 
@@ -55,14 +66,19 @@ Puis lancer les fixtures <br>
 Vérifier si les fixtures on été chargées en BDD.
 
 ### ✅ Récupérer les articles
-Création du PostController et la méthode index. Dans le PostController, création d'une variable post qui permet de récupérer
+
+Création du PostController et la méthode index. Dans le PostController, création d'une variable post qui permet de
+récupérer
 la totalité des post grâce au Repository. Utilisation de la méthode render afin de renvoyer les données à la vue.
 
 ### ✅ Création d'une requête personnalisée
+
 Création de la requête personnalisée dans le repository.
 
 ### 🔥 Installation de TailwindCSS
-Grâce à [Youri Galescot](https://www.yourigalescot.com/fr/blog/comment-integrer-tailwindcss-v3-a-un-projet-symfony-avec-webpack-encore)
+
+Grâce
+à [Youri Galescot](https://www.yourigalescot.com/fr/blog/comment-integrer-tailwindcss-v3-a-un-projet-symfony-avec-webpack-encore)
 on a une roadmap bien rodé pour installer correctement TailwindCSS. <br>
 Installer Tailwind, postcss et autoprefixer <br>
 ```yarn add --dev tailwindcss postcss autoprefixer``` <br>
@@ -72,6 +88,7 @@ Ensuite on install le loader PostCSS <br>
 Ensuite on active PostCSS dans le **webpack.config.js** en ajoutant la ligne suivante : <br>
 ```.enablePostCssLoader()``` <br>
 On crée le fichier **postcss.config.js** dans lequel on ajoute les modules d'export :
+
 ```
 module.exports = {
     plugins: {
@@ -80,16 +97,20 @@ module.exports = {
     }
 };
 ```
-Enfin, dans **app.css** on indique à Tailwind les différentes couches 
+
+Enfin, dans **app.css** on indique à Tailwind les différentes couches
+
 ```
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 ```
+
 Et pour finir on lance build les assets : <br>
 ```yarn run dev --watch```
 
 Ensuite on implémente le tout dans Twig.
+
 ```
     <div class="h-screen flex flex-col items-center justify-center">
         <h1 class="text-gray-500 text-4xl mb-4">Hello world</h1>
@@ -98,6 +119,7 @@ Ensuite on implémente le tout dans Twig.
         </button>
     </div>
 ```
+
 Petit+ <br>
 Il est possible d'utiliser Tailwind Elements. On peut l'installer avec : <br>
 ```yarn add tw-elements```
@@ -105,28 +127,35 @@ Il est possible d'utiliser Tailwind Elements. On peut l'installer avec : <br>
 Il fait indiquer à Tailwind d'utiliser Tw-elements : <br>
 ```./node_modules/tw-elements/dist/js/**/*.js```
 et l'ajouter comme plugin :
+
 ```
   plugins: [
       require('tw-elements/dist/plugin')
   ],
 ```
+
 Intégrer les fichiers js de Tailwind elements dans app.js : <br>
 ``ìmport 'tw-elements''``
 
-### ✅Créer les cards pour les posts
+### ✅ Créer les cards pour les posts
+
 Créer les cards.
 Astuce : il est possible de rajouter un 'u' dans les variables twig en installant le composant suivant : <br>
+
 ```
 composer require twig/string-extra
 ```
 
-### ✅Créer un composant
+### ✅ Créer un composant
+
 Créer un composant pour réutiliser les cards.
 
 ### 🔥 Pagination avec KNP Paginator
+
 Installer le bundle <br>
 ```composer require knplabs/knp-paginator-bundle``` <br>
 Mettre en place la pagination dans le controller : <br>
+
 ```
     #[Route('/', name: 'post.index', methods: ['GET'])]
     public function index(
@@ -147,6 +176,7 @@ Mettre en place la pagination dans le controller : <br>
         ]);
     }    
 ```
+
 Ajouter la configuration de knp_paginator dans le dossier config
 
 ```
@@ -164,7 +194,9 @@ knp_paginator:
         sortable: '@KnpPaginator/Pagination/sortable_link.html.twig' # sort link template
         filtration: '@KnpPaginator/Pagination/filtration.html.twig'  # filters template
 ```
+
 Dans le fichier **index.html.twig** ajouter une div qui contient la pagination : <br>
+
 ```
 <div class="navigation flex justify-content mb-8">
     {{ knp_pagination_render(posts) }}
@@ -172,20 +204,44 @@ Dans le fichier **index.html.twig** ajouter une div qui contient la pagination :
 ```
 
 ### 🔥 Retourner directement des articles paginés
+
 Au lieu de retourner des articles, puis de les paginer il est beaucoup plus logique de
 les paginer dans la requête du **repository**. Au lieu d'avoir la logique de la pagination dans le repo
 on met tout dans le repository :
+
 ```
 return $post = $this->paginator->paginate($data, $page, 9);
 ```
 
 ### 🔥 Modifier le style de la pagination
-Pour modifier le style, on peut ajouter un style prédéfini dans <span style="color:blue">*/vendor/knplabs/knp-paginator-bundle/templates/Pagination/*</span>
-Ou alors on peut créer son propre design dans un dossier et l'appliquer dans le fichier de configuration de knp-paginator.
+
+Pour modifier le style, on peut ajouter un style prédéfini dans <span style="color:blue">
+*/vendor/knplabs/knp-paginator-bundle/templates/Pagination/*</span>
+Ou alors on peut créer son propre design dans un dossier et l'appliquer dans le fichier de configuration de
+knp-paginator.
 
 ### 📝 Tester une page
-Pour créer un test fonctionnel il est possible de passer la console de symfony <br>
+
+Pour créer un test fonctionnel, il est possible de passer la console de symfony <br>
 ```php bin/console make:test``` <br>
 Choisir le type de test et le nom de la classe à tester. Puis lancer le test. <br>
 ```php bin/phpunit```
+
+### ✅ Ajouter un Header et un footer
+
+### ✅ Créer la page détail d'un article grâce au ParamConverter
+
+Dans la fonction show, au lieu de passer par le repository, on peut utiliser l'injection de dépendance en passant
+l'objet pour atteindre le slug et les informations dont on a besoin. C'est le ParamConverter : de manière automatique, 
+Symfony comprend que l'on souhaite avoir accès à l'objet et à tous ses composants.
+
+```
+    #[Route('/article/{slug}', name: 'post.show', methods: ['GET'])]
+    public function show(Post $post, PostRepository $postRepository): Response
+    {
+        return $this->render('pages/blog/show.html.twig', [
+            'post' => $post,
+        ]);
+    }
+```
 

--- a/src/Controller/Blog/PostController.php
+++ b/src/Controller/Blog/PostController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\Blog;
 
+use App\Entity\Post\Post;
 use App\Repository\Post\PostRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,5 +20,13 @@ class PostController extends AbstractController
         return $this->render('pages/blog/index.html.twig', [
             'posts' => $post = $postRepository->findPublished($request->query->getInt('page', 1)),
         ]);
-    }    
+    }
+
+    #[Route('/article/{slug}', name: 'post.show', methods: ['GET'])]
+    public function show(Post $post, PostRepository $postRepository): Response
+    {
+        return $this->render('pages/blog/show.html.twig', [
+            'post' => $post,
+        ]);
+    }
 }

--- a/templates/components/_cards.html.twig
+++ b/templates/components/_cards.html.twig
@@ -1,5 +1,4 @@
-<div class="max-w-sm bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800
-                            dark:border-gray-700 my-8 mr-4">
+<div class="max-w-sm bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700 my-8 mr-4">
     {% if post.thumbnail %}
         <a href="">
             <img src="{{ vich_uploader_asset(post.thumbnail, 'imageFile') }}"
@@ -8,7 +7,7 @@
         </a>
     {% endif %}
     <div class="p-5">
-        <a href="#">
+        <a href="{{ path('post.show', {slug: post.slug}) }}">
             <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
                 {{ post.title|capitalize }}
             </h5>
@@ -16,7 +15,7 @@
         <p class="mb-3 font-normal text-gray-700 dark:text-gray-400">
             {{ post.content|u.truncate(160, '...') }}
         </p>
-        <a href="#" class="inline-flex items-center py-2 px-3 text-sm font-medium text-center
+        <a href="{{ path('post.show', {slug: post.slug}) }}" class="inline-flex items-center py-2 px-3 text-sm font-medium text-center
                         text-white bg-red-700 rounded-lg hover:bg-red-700 focus:ring-4 focus:outline-none
                         focus:ring-blue-300 dark:bg-red-700 dark:hover:bg-red-700 dark:focus:ring-red-700">
             Lire Plus

--- a/templates/pages/blog/show.html.twig
+++ b/templates/pages/blog/show.html.twig
@@ -1,0 +1,88 @@
+{% extends "base.html.twig" %}
+
+{% block title %}
+    {{ post.title }}
+{% endblock %}
+
+{% block body %}
+    <div class="container mx-auto">
+        <div class="w-2/3 mx-auto mt-6">
+            <a href="{{ path('post.index') }}" class="inline-flex items-center py-2 px-3 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
+                Retourner au blog
+            </a>
+        </div>
+
+        <div class="mt-6">
+            {% for message in app.flashes('success') %}
+                {% include "components/_alert.html.twig" with {
+                    'message': message
+                } %}
+            {% endfor %}
+        </div>
+
+
+        <h1 class="text-5xl text-center mt-8 mb-4 text-blue-700">{{ post.title|capitalize }}!</h1>
+        <h2 class="text-2xl text-center mb-8">Publié le
+            {{ post.createdAt|date('d/m/Y') }}</h2>
+
+{#        {% include "components/_share.html.twig" %}#}
+
+        {% if post.thumbnail %}
+            <img class="rounded-t-lg" src="{{ vich_uploader_asset(post.thumbnail, 'imageFile') }}" alt="{{ post.thumbnail.imageName }}">
+        {% endif %}
+
+{#        <div class="w-2/3 mx-auto my-8 leading-6">#}
+{#            {% include "components/_badges.html.twig" with {#}
+{#                badges: post.categories#}
+{#            } only %}#}
+{#        </div>#}
+
+        <div class="w-2/3 mx-auto my-8 leading-6">
+            {{ post.content|raw }}
+            <p class="text-xs mt-8">Dernière mis à jour le
+                {{ post.updatedAt|date('d/m/Y') }}</p>
+        </div>
+
+{#        <div class="w-2/3 mx-auto my-8 leading-6">#}
+{#            <ul class="flex flex-row justify-start text-xs mt-8">#}
+{#                <li>Étiquettes: &nbsp;</li>#}
+{#                {% for tag in post.tags %}#}
+{#                    <li>#}
+{#                        <a href="{{ path('tag.index', {slug: tag.slug}) }}">{{ tag.name }}</a>#}
+
+{#                        {% if not loop.last %}#}
+{#                            <span>&nbsp; - &nbsp;</span>#}
+{#                        {% endif %}#}
+{#                    </li>#}
+{#                {% endfor %}#}
+{#            </ul>#}
+
+{#            <div class="mt-5">#}
+{#                <h2 class="text-2xl mb-8">Commentaire(s)</h2>#}
+{#                <div class="comments">#}
+{#                    {% if app.user %}#}
+{#                        <div class="comments__new">#}
+{#                            <div class="w-full-width">#}
+{#                                {{ form_start(form) }}#}
+{#                                {{ form_label(form.content, 'Nouveau commentaire', {'attr' : {'class' : 'form-label inline-block mb-2 text-gray-700'}}) }}#}
+{#                                {{ form_widget(form.content, {'attr': {'class': 'form-control block w-full px-3 py-1.5 text-base font-normal text-gray-700 bg-white bg-clip-padding border border-solid border-gray-300 rounded transition ease-in-out m-0 focus:text-gray-700 focus:bg-white focus:border-blue-600 focus:outline-none'}}) }}#}
+{#                                <button class="btn inline-block px-6 py-2.5 bg-blue-600 text-white font-medium text-xs leading-tight uppercase rounded shadow-md hover:bg-blue-700 hover:shadow-lg focus:bg-blue-700  focus:shadow-lg focus:outline-none focus:ring-0 active:bg-blue-800 active:shadow-lg transition duration-150 ease-in-out flex items-center mt-5" type="submit" id="button-addon2">#}
+{#                                    Poster mon commentaire#}
+{#                                </button>#}
+
+{#                                {{ form_end(form) }}#}
+{#                            </div>#}
+{#                        </div>#}
+{#                    {% endif %}#}
+
+{#                    <hr class="my-3">#}
+
+{#                    {% for comment in post.comments %}#}
+{#                        {% include 'components/_comment.html.twig' %}#}
+{#                    {% endfor %}#}
+{#                </div>#}
+{#            </div>#}
+{#        </div>#}
+
+    </div>
+{% endblock %}


### PR DESCRIPTION
### ✅ Créer la page détail d'un article grâce au ParamConverter

Dans la fonction show, au lieu de passer par le repository, on peut utiliser l'injection de dépendance en passant
l'objet pour atteindre le slug et les informations dont on a besoin. C'est le ParamConverter : de manière automatique, 
Symfony comprend que l'on souhaite avoir accès à l'objet et à tous ses composants.

```
    #[Route('/article/{slug}', name: 'post.show', methods: ['GET'])]
    public function show(Post $post, PostRepository $postRepository): Response
    {
        return $this->render('pages/blog/show.html.twig', [
            'post' => $post,
        ]);
    }
```